### PR TITLE
Add and remove some abilities of main.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+CMCCModelConfig.json

--- a/main.py
+++ b/main.py
@@ -1,13 +1,68 @@
 import os
+import json
 import re
 import subprocess
+import sys
 import telnetlib
 import time
 
 import requests
 from loguru import logger
-import json
-import sys
+
+
+HOST_PATTERN = re.compile(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
+MAC_PATTERN = re.compile(r"^[0-9A-F]{12}$")
+
+
+def is_yes_response(response):
+    return isinstance(response, str) and response.strip().lower() == "y"
+
+
+def validate_host(host):
+    return isinstance(host, str) and bool(HOST_PATTERN.fullmatch(host.strip()))
+
+
+def normalize_mac_address(mac_address):
+    if not isinstance(mac_address, str):
+        return None
+
+    normalized = mac_address.strip().upper().replace("-", "").replace(":", "")
+    if not MAC_PATTERN.fullmatch(normalized):
+        return None
+    return normalized
+
+
+def load_config(config_file):
+    with open(config_file, "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    host = str(config.get("host", "")).strip()
+    mac_address = normalize_mac_address(config.get("mac_address", ""))
+    if not validate_host(host) or not mac_address:
+        raise ValueError("Invalid host or MAC address in configuration file.")
+
+    return {
+        "date": config.get("date", "unknown"),
+        "host": host,
+        "mac_address": mac_address,
+    }
+
+
+def save_config(config_file, host, mac_address):
+    host = host.strip() if isinstance(host, str) else ""
+    mac_address = normalize_mac_address(mac_address)
+    if not validate_host(host) or not mac_address:
+        raise ValueError("Cannot save invalid host or MAC address.")
+
+    datenow = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    with open(config_file, "w", encoding="utf-8") as f:
+        json.dump({
+            "date": datenow,
+            "host": host,
+            "mac_address": mac_address,
+        }, f, ensure_ascii=False, indent=2)
+    return datenow
+
 
 def clear_console():
     rows, columns = os.get_terminal_size()
@@ -42,17 +97,14 @@ class ModemManager:
 
     def set_host(self):
         host = input("Please enter the IP address of the modem (default:192.168.0.1): ") or "192.168.0.1"
-        if not isinstance(host, str):
-            raise TypeError("Host address must be a string.")
-        if not host:
-            raise ValueError("Host address must not be empty.")
-        if not re.match(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", host):
+        if not validate_host(host):
             raise ValueError("Invalid host address.")
-        self.host = host
+        self.host = host.strip()
         logger.info(f"Host set to: {self.host}")
         return self.host
 
     def get_mac_address(self):
+        mac_address = None
         try:
             arp_result = subprocess.check_output("arp -a", shell=True).decode('utf-8')
         except UnicodeDecodeError:
@@ -76,16 +128,16 @@ class ModemManager:
                 break
         else:
             logger.error(f"Failed to obtain MAC address from ARP table for host {self.host}")
-            if input("Failed to get MAC address. Enter manually? [Y/Others] ") in "Yy":
+            if is_yes_response(input("Failed to get MAC address. Enter manually? [Y/Others] ")):
                 mac_address = input("Mac Address(like ff-ff-ff-ff-ff-ff): ")
             else:
                 mac_address = None
-        if not mac_address:
-            logger.error("Failed to obtain MAC address.")
+        normalized_mac_address = normalize_mac_address(mac_address)
+        if not normalized_mac_address:
+            logger.error("Failed to obtain a valid MAC address.")
             return None
-        mac_address = mac_address.upper().replace("-", "")
-        logger.info(f"MAC Address obtained successfully: {mac_address}")
-        return mac_address
+        logger.info(f"MAC Address obtained successfully: {normalized_mac_address}")
+        return normalized_mac_address
 
     def enable_telnet(self):
         url = f"http://{self.host}/cgi-bin/telnetenable.cgi?telnetenable=1&key={self.mac_address}"
@@ -195,16 +247,15 @@ class ModemManager:
         '''
         readconfig=False
         if os.path.exists(ConfigFile):
-            if input("Do you want to use the old Configuration file? [Y/Others] ") in "Yy":
-                readconfig=True
+            if is_yes_response(input("Do you want to use the old Configuration file? [Y/Others] ")):
                 logger.info(f"Reading Config...")
                 try:
-                    with open(ConfigFile,"r") as f:
-                        Config = json.loads(f.read())
-                        self.host = Config["host"]
-                        self.mac_address = Config["mac_address"]
-                        logger.info(f"Last Config: {ConfigFile} on {Config["date"]}")
-                except:
+                    Config = load_config(ConfigFile)
+                    self.host = Config["host"]
+                    self.mac_address = Config["mac_address"]
+                    logger.info(f"Last Config: {ConfigFile} on {Config['date']}")
+                    readconfig=True
+                except Exception:
                     logger.error(f"Failed to read configuration. Please delete: {ConfigFile} and try again. Error details below:")
                     raise
         if readconfig==False:
@@ -221,14 +272,11 @@ class ModemManager:
             logger.info(
                 "Please follow the manual confirmation steps at "
                 "`https://www.bilibili.com/read/cv21044770/` and modify the code if necessary.")
-        if input("Do you want to save the configuration? [Y/Others] ") in "Yy":
+        if self.host and self.mac_address and is_yes_response(input("Do you want to save the configuration? [Y/Others] ")):
             try:
-                with open(ConfigFile,"w+") as f:
-                    datenow=time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-                    Config=json.dumps({"date": datenow, "host":self.host, "mac_address":self.mac_address})
-                    f.write(Config)
-                    logger.info(f"Save Config: {ConfigFile} on {datenow}")
-            except:
+                datenow = save_config(ConfigFile, self.host, self.mac_address)
+                logger.info(f"Save Config: {ConfigFile} on {datenow}")
+            except Exception:
                 logger.error(f"Failed to write configuration. Please check read/write permissions for {ConfigFile} .Error details below:")
                 raise
         exit(0)

--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ import time
 
 import requests
 from loguru import logger
-
+import json
+import sys
 
 def clear_console():
     rows, columns = os.get_terminal_size()
@@ -62,7 +63,7 @@ class ModemManager:
         if not arp_result:
             logger.error("Failed to obtain ARP table.")
             return None
-        logger.debug(arp_result)
+        # logger.debug(arp_result)
         lines = arp_result.split("\n")
         for line in lines:
             line = line.strip()
@@ -75,7 +76,10 @@ class ModemManager:
                 break
         else:
             logger.error(f"Failed to obtain MAC address from ARP table for host {self.host}")
-            return None
+            if input("Failed to get MAC address. Enter manually? [Y/Others] ") in "Yy":
+                mac_address = input("Mac Address(like ff-ff-ff-ff-ff-ff): ")
+            else:
+                mac_address = None
         if not mac_address:
             logger.error("Failed to obtain MAC address.")
             return None
@@ -171,7 +175,7 @@ class ModemManager:
                         return None
                 else:
                     return None
-            logger.debug(f"Telenet Result: {result}")
+            # logger.debug(f"Telenet Result: {result}")
         return admin_username, admin_password
 
     def manage_modem(self):
@@ -181,11 +185,34 @@ class ModemManager:
             return False
 
     def main(self):
-        self.host = self.set_host()
-        self.mac_address = self.get_mac_address()
+        ConfigFile=os.path.join(sys.path[0],'CMCCModelConfig.json')
+        '''Configuration file CMCCModelConfig.json
+        {
+            "date":"1970-1-1 00:00:00",
+            "host":"182.168.0.1",
+            "mac_address":"ffffffffffff"
+        }
+        '''
+        readconfig=False
+        if os.path.exists(ConfigFile):
+            if input("Do you want to use the old Configuration file? [Y/Others] ") in "Yy":
+                readconfig=True
+                logger.info(f"Reading Config...")
+                try:
+                    with open(ConfigFile,"r") as f:
+                        Config = json.loads(f.read())
+                        self.host = Config["host"]
+                        self.mac_address = Config["mac_address"]
+                        logger.info(f"Last Config: {ConfigFile} on {Config["date"]}")
+                except:
+                    logger.error(f"Failed to read configuration. Please delete: {ConfigFile} and try again. Error details below:")
+                    raise
+        if readconfig==False:
+            self.host = self.set_host()
+            self.mac_address = self.get_mac_address()
         data = self.manage_modem()
         if isinstance(data, tuple) and data:
-            clear_console()
+            # clear_console()
             logger.info(f"Sucessfully obtained Admin Username and Password for {self.host}!")
             logger.info(f"Username: {data[0]}")
             logger.info(f"Password: {data[1]}")
@@ -194,7 +221,17 @@ class ModemManager:
             logger.info(
                 "Please follow the manual confirmation steps at "
                 "`https://www.bilibili.com/read/cv21044770/` and modify the code if necessary.")
-            exit(0)
+        if input("Do you want to save the configuration? [Y/Others] ") in "Yy":
+            try:
+                with open(ConfigFile,"w+") as f:
+                    datenow=time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+                    Config=json.dumps({"date": datenow, "host":self.host, "mac_address":self.mac_address})
+                    f.write(Config)
+                    logger.info(f"Save Config: {ConfigFile} on {datenow}")
+            except:
+                logger.error(f"Failed to write configuration. Please check read/write permissions for {ConfigFile} .Error details below:")
+                raise
+        exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,0 +1,66 @@
+import json
+import os
+import tempfile
+import unittest
+
+from main import is_yes_response, load_config, normalize_mac_address, save_config, validate_host
+
+
+class MainHelperTests(unittest.TestCase):
+    def test_is_yes_response_only_accepts_y(self):
+        self.assertTrue(is_yes_response("Y"))
+        self.assertTrue(is_yes_response(" y "))
+        self.assertFalse(is_yes_response(""))
+        self.assertFalse(is_yes_response("yes"))
+        self.assertFalse(is_yes_response("n"))
+
+    def test_normalize_mac_address_accepts_common_formats(self):
+        self.assertEqual(normalize_mac_address("ff-ff-ff-ff-ff-ff"), "FFFFFFFFFFFF")
+        self.assertEqual(normalize_mac_address("ff:ff:ff:ff:ff:ff"), "FFFFFFFFFFFF")
+        self.assertEqual(normalize_mac_address("ffffffffffff"), "FFFFFFFFFFFF")
+
+    def test_normalize_mac_address_rejects_invalid_values(self):
+        self.assertIsNone(normalize_mac_address(""))
+        self.assertIsNone(normalize_mac_address("ff-ff"))
+        self.assertIsNone(normalize_mac_address("zz-zz-zz-zz-zz-zz"))
+
+    def test_validate_host(self):
+        self.assertTrue(validate_host("192.168.0.1"))
+        self.assertFalse(validate_host(""))
+        self.assertFalse(validate_host("999.168.0.1"))
+        self.assertFalse(validate_host("not-an-ip"))
+
+    def test_load_config_normalizes_valid_config(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "CMCCModelConfig.json")
+            with open(config_file, "w", encoding="utf-8") as file:
+                json.dump({
+                    "date": "2026-01-01 00:00:00",
+                    "host": "192.168.0.1",
+                    "mac_address": "ff-ff-ff-ff-ff-ff",
+                }, file)
+
+            config = load_config(config_file)
+
+            self.assertEqual(config["host"], "192.168.0.1")
+            self.assertEqual(config["mac_address"], "FFFFFFFFFFFF")
+
+    def test_load_config_rejects_invalid_config(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "CMCCModelConfig.json")
+            with open(config_file, "w", encoding="utf-8") as file:
+                json.dump({"host": "999.168.0.1", "mac_address": "ff-ff"}, file)
+
+            with self.assertRaises(ValueError):
+                load_config(config_file)
+
+    def test_save_config_rejects_invalid_values(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "CMCCModelConfig.json")
+
+            with self.assertRaises(ValueError):
+                save_config(config_file, "192.168.0.1", None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CN
- 导入了json和sys模块。
- 当无法获取MAC地址时，将提示手动输入MAC地址。
- 添加了从配置读取host和mac地址的功能。当需要重新获取密码时，可以选择使用之前的配置。
- 添加了将host和mac地址保存进配置文件的功能。
- 注释了一些debug输出。
- 注释了clear_console()的调用。

EN
- import json and sys.
- When unable to obtain the MAC address, it will prompt to manually enter the MAC address.
- Added the ability to read host and MAC addresses from configuration. When it is necessary to retrieve the password again, you can choose to use the previous configuration.
- Added the ability to save the host and MAC address into the configuration file.
- Annotated some debug outputs.
- Annotated the call to clear_comsole() .